### PR TITLE
Add table name prefixes in SELECT statment for fields

### DIFF
--- a/builder/buffer.go
+++ b/builder/buffer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -16,7 +15,6 @@ import (
 
 // UnescapeCharacter disable field escaping when it starts with this character.
 var UnescapeCharacter byte = '^'
-var regexNumber = regexp.MustCompile(`^\d+$`)
 
 var escapeCache sync.Map
 
@@ -132,7 +130,7 @@ func (b Buffer) escape(table, value string) string {
 
 	if len(value) > 0 && value[0] == UnescapeCharacter {
 		escapedValue = value[1:]
-	} else if regexNumber.MatchString(value) {
+	} else if _, err := strconv.Atoi(value); err == nil {
 		escapedValue = value
 	} else if i := strings.Index(strings.ToLower(value), " as "); i > -1 {
 		escapedValue = b.escape(table, value[:i]) + " AS " + b.escape("", value[i+4:])

--- a/builder/buffer_test.go
+++ b/builder/buffer_test.go
@@ -12,6 +12,7 @@ func TestBuffer_escape(t *testing.T) {
 	buffer := Buffer{Quoter: Quote{IDPrefix: "[", IDSuffix: "]"}}
 
 	tests := []struct {
+		table  string
 		field  string
 		result string
 	}{
@@ -24,6 +25,7 @@ func TestBuffer_escape(t *testing.T) {
 			result: "[user].[address] AS [home_address]",
 		},
 		{
+			table:  "ignored",
 			field:  "^FIELD([gender], \"male\") AS order",
 			result: "FIELD([gender], \"male\") AS order",
 		},
@@ -35,11 +37,26 @@ func TestBuffer_escape(t *testing.T) {
 			field:  "user.*",
 			result: "[user].*",
 		},
+		{
+			table:  "user",
+			field:  "*",
+			result: "[user].*",
+		},
+		{
+			table:  "user",
+			field:  "address as home_address",
+			result: "[user].[address] AS [home_address]",
+		},
+		{
+			table:  "user",
+			field:  "count(*) as count",
+			result: "count([user].*) AS [count]",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.result, func(t *testing.T) {
 			var (
-				result = buffer.escape(test.field)
+				result = buffer.escape(test.table, test.field)
 			)
 
 			assert.Equal(t, test.result, result)

--- a/builder/buffer_test.go
+++ b/builder/buffer_test.go
@@ -52,6 +52,11 @@ func TestBuffer_escape(t *testing.T) {
 			field:  "count(*) as count",
 			result: "count([user].*) AS [count]",
 		},
+		{
+			table:  "user",
+			field:  "person.address as home_address",
+			result: "[person].[address] AS [home_address]",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.result, func(t *testing.T) {

--- a/builder/delete.go
+++ b/builder/delete.go
@@ -22,7 +22,7 @@ func (ds Delete) Build(table string, filter rel.FilterQuery) (string, []interfac
 
 	if !filter.None() {
 		buffer.WriteString(" WHERE ")
-		ds.Filter.Write(&buffer, filter, ds.Query)
+		ds.Filter.Write(&buffer, "", filter, ds.Query)
 	}
 
 	buffer.WriteString(";")

--- a/builder/delete.go
+++ b/builder/delete.go
@@ -22,7 +22,7 @@ func (ds Delete) Build(table string, filter rel.FilterQuery) (string, []interfac
 
 	if !filter.None() {
 		buffer.WriteString(" WHERE ")
-		ds.Filter.Write(&buffer, "", filter, ds.Query)
+		ds.Filter.Write(&buffer, table, filter, ds.Query)
 	}
 
 	buffer.WriteString(";")

--- a/builder/delete_test.go
+++ b/builder/delete_test.go
@@ -23,7 +23,7 @@ func TestDelete_Builder(t *testing.T) {
 	assert.Equal(t, []interface{}(nil), args)
 
 	qs, args = deleteBuilder.Build("users", where.Eq("id", 1))
-	assert.Equal(t, "DELETE FROM `users` WHERE `id`=?;", qs)
+	assert.Equal(t, "DELETE FROM `users` WHERE `users`.`id`=?;", qs)
 	assert.Equal(t, []interface{}{1}, args)
 }
 
@@ -43,6 +43,6 @@ func TestDelete_Builder_ordinal(t *testing.T) {
 	assert.Equal(t, []interface{}(nil), args)
 
 	qs, args = deleteBuilder.Build("users", where.Eq("id", 1))
-	assert.Equal(t, "DELETE FROM \"users\" WHERE \"id\"=$1;", qs)
+	assert.Equal(t, "DELETE FROM \"users\" WHERE \"users\".\"id\"=$1;", qs)
 	assert.Equal(t, []interface{}{1}, args)
 }

--- a/builder/filter_test.go
+++ b/builder/filter_test.go
@@ -18,6 +18,7 @@ func TestFilter_Write(t *testing.T) {
 	tests := []struct {
 		result string
 		args   []interface{}
+		table  string
 		filter rel.FilterQuery
 	}{
 		{
@@ -176,7 +177,7 @@ func TestFilter_Write(t *testing.T) {
 				buffer = bufferFactory.Create()
 			)
 
-			filterBuilder.Write(&buffer, test.filter, queryBuilder)
+			filterBuilder.Write(&buffer, test.table, test.filter, queryBuilder)
 
 			assert.Equal(t, test.result, buffer.String())
 			assert.Equal(t, test.args, buffer.Arguments())
@@ -194,6 +195,7 @@ func TestFilter_Write_ordinal(t *testing.T) {
 	tests := []struct {
 		result string
 		args   []interface{}
+		table  string
 		filter rel.FilterQuery
 	}{
 		{
@@ -353,7 +355,7 @@ func TestFilter_Write_ordinal(t *testing.T) {
 				buffer = bufferFactory.Create()
 			)
 
-			filterBuilder.Write(&buffer, test.filter, queryBuilder)
+			filterBuilder.Write(&buffer, test.table, test.filter, queryBuilder)
 
 			assert.Equal(t, test.result, buffer.String())
 			assert.Equal(t, test.args, buffer.Arguments())

--- a/builder/index.go
+++ b/builder/index.go
@@ -62,7 +62,7 @@ func (i Index) WriteCreateIndex(buffer *Buffer, index rel.Index) {
 			return
 		}
 		buffer.WriteString(" WHERE ")
-		i.Filter.Write(buffer, index.Filter, i.Query)
+		i.Filter.Write(buffer, "", index.Filter, i.Query)
 	}
 }
 

--- a/builder/query.go
+++ b/builder/query.go
@@ -38,7 +38,7 @@ func (q Query) Write(buffer *Buffer, query rel.Query) {
 
 	rootQuery := buffer.Len() == 0
 
-	q.WriteSelect(buffer, query.SelectQuery)
+	q.WriteSelect(buffer, query.Table, query.SelectQuery)
 	q.WriteQuery(buffer, query)
 
 	if rootQuery {
@@ -47,13 +47,13 @@ func (q Query) Write(buffer *Buffer, query rel.Query) {
 }
 
 // WriteSelect SQL to buffer.
-func (q Query) WriteSelect(buffer *Buffer, selectQuery rel.SelectQuery) {
+func (q Query) WriteSelect(buffer *Buffer, table string, selectQuery rel.SelectQuery) {
 	if len(selectQuery.Fields) == 0 {
+		buffer.WriteString("SELECT ")
 		if selectQuery.OnlyDistinct {
-			buffer.WriteString("SELECT DISTINCT *")
-			return
+			buffer.WriteString("DISTINCT ")
 		}
-		buffer.WriteString("SELECT *")
+		buffer.WriteField(table, "*")
 		return
 	}
 
@@ -65,7 +65,7 @@ func (q Query) WriteSelect(buffer *Buffer, selectQuery rel.SelectQuery) {
 
 	l := len(selectQuery.Fields) - 1
 	for i, f := range selectQuery.Fields {
-		buffer.WriteEscape(f)
+		buffer.WriteField(table, f)
 
 		if i < l {
 			buffer.WriteByte(',')
@@ -77,14 +77,14 @@ func (q Query) WriteSelect(buffer *Buffer, selectQuery rel.SelectQuery) {
 func (q Query) WriteQuery(buffer *Buffer, query rel.Query) {
 	q.WriteFrom(buffer, query.Table)
 	q.WriteJoin(buffer, query.Table, query.JoinQuery)
-	q.WriteWhere(buffer, query.WhereQuery)
+	q.WriteWhere(buffer, query.Table, query.WhereQuery)
 
 	if len(query.GroupQuery.Fields) > 0 {
-		q.WriteGroupBy(buffer, query.GroupQuery.Fields)
-		q.WriteHaving(buffer, query.GroupQuery.Filter)
+		q.WriteGroupBy(buffer, query.Table, query.GroupQuery.Fields)
+		q.WriteHaving(buffer, query.Table, query.GroupQuery.Filter)
 	}
 
-	q.WriteOrderBy(buffer, query.SortQuery)
+	q.WriteOrderBy(buffer, query.Table, query.SortQuery)
 	q.WriteLimitOffet(buffer, query.LimitQuery, query.OffsetQuery)
 
 	if query.LockQuery != "" {
@@ -134,22 +134,22 @@ func (q Query) WriteJoin(buffer *Buffer, table string, joins []rel.JoinQuery) {
 }
 
 // WriteWhere SQL to buffer.
-func (q Query) WriteWhere(buffer *Buffer, filter rel.FilterQuery) {
+func (q Query) WriteWhere(buffer *Buffer, table string, filter rel.FilterQuery) {
 	if filter.None() {
 		return
 	}
 
 	buffer.WriteString(" WHERE ")
-	q.Filter.Write(buffer, filter, q)
+	q.Filter.Write(buffer, table, filter, q)
 }
 
 // WriteGroupBy SQL to buffer.
-func (q Query) WriteGroupBy(buffer *Buffer, fields []string) {
+func (q Query) WriteGroupBy(buffer *Buffer, table string, fields []string) {
 	buffer.WriteString(" GROUP BY ")
 
 	l := len(fields) - 1
 	for i, f := range fields {
-		buffer.WriteEscape(f)
+		buffer.WriteField(table, f)
 
 		if i < l {
 			buffer.WriteByte(',')
@@ -158,17 +158,17 @@ func (q Query) WriteGroupBy(buffer *Buffer, fields []string) {
 }
 
 // WriteHaving SQL to buffer.
-func (q Query) WriteHaving(buffer *Buffer, filter rel.FilterQuery) {
+func (q Query) WriteHaving(buffer *Buffer, table string, filter rel.FilterQuery) {
 	if filter.None() {
 		return
 	}
 
 	buffer.WriteString(" HAVING ")
-	q.Filter.Write(buffer, filter, q)
+	q.Filter.Write(buffer, table, filter, q)
 }
 
 // WriteOrderBy SQL to buffer.
-func (q Query) WriteOrderBy(buffer *Buffer, orders []rel.SortQuery) {
+func (q Query) WriteOrderBy(buffer *Buffer, table string, orders []rel.SortQuery) {
 	var (
 		length = len(orders)
 	)
@@ -183,7 +183,7 @@ func (q Query) WriteOrderBy(buffer *Buffer, orders []rel.SortQuery) {
 			buffer.WriteString(", ")
 		}
 
-		buffer.WriteEscape(order.Field)
+		buffer.WriteField(table, order.Field)
 
 		if order.Asc() {
 			buffer.WriteString(" ASC")

--- a/builder/query_test.go
+++ b/builder/query_test.go
@@ -45,7 +45,7 @@ func TestQuery_Build(t *testing.T) {
 		query  rel.Query
 	}{
 		{
-			result: "SELECT * FROM `users`;",
+			result: "SELECT `users`.* FROM `users`;",
 			query:  query,
 		},
 		{
@@ -53,45 +53,49 @@ func TestQuery_Build(t *testing.T) {
 			query:  query.Select("users.*"),
 		},
 		{
-			result: "SELECT `id`,`name` FROM `users`;",
+			result: "SELECT `users`.`id`,`users`.`name` FROM `users`;",
 			query:  query.Select("id", "name"),
 		},
 		{
-			result: "SELECT `id`,FIELD(`gender`, \"male\") AS `order` FROM `users` ORDER BY `order` ASC;",
-			query:  query.Select("id", "^FIELD(`gender`, \"male\") AS `order`").SortAsc("order"),
+			result: "SELECT `users`.`id`,FIELD(`gender`, \"male\") AS `order` FROM `users` ORDER BY order ASC;",
+			query:  query.Select("id", "^FIELD(`gender`, \"male\") AS `order`").SortAsc("^order"),
 		},
 		{
-			result: "SELECT * FROM `users` JOIN `transactions` ON `transactions`.`id`=`users`.`transaction_id`;",
+			result: "SELECT `users`.`id`,FIELD(`gender`, \"male\") AS `order` FROM `users` ORDER BY 2 ASC;",
+			query:  query.Select("id", "^FIELD(`gender`, \"male\") AS `order`").SortAsc("2"),
+		},
+		{
+			result: "SELECT `users`.* FROM `users` JOIN `transactions` ON `transactions`.`id`=`users`.`transaction_id`;",
 			query:  query.JoinOn("transactions", "transactions.id", "users.transaction_id"),
 		},
 		{
-			result: "SELECT * FROM `users` WHERE `id`=?;",
+			result: "SELECT `users`.* FROM `users` WHERE `users`.`id`=?;",
 			args:   []interface{}{10},
 			query:  query.Where(where.Eq("id", 10)),
 		},
 		{
-			result: "SELECT DISTINCT * FROM `users` GROUP BY `type` HAVING `price`>?;",
+			result: "SELECT DISTINCT `users`.* FROM `users` GROUP BY `users`.`type` HAVING `users`.`price`>?;",
 			args:   []interface{}{1000},
 			query:  query.Distinct().Group("type").Having(where.Gt("price", 1000)),
 		},
 		{
-			result: "SELECT * FROM `users` INNER JOIN `transactions` ON `transactions`.`id`=`users`.`transaction_id`;",
+			result: "SELECT `users`.* FROM `users` INNER JOIN `transactions` ON `transactions`.`id`=`users`.`transaction_id`;",
 			query:  query.JoinWith("INNER JOIN", "transactions", "transactions.id", "users.transaction_id"),
 		},
 		{
-			result: "SELECT * FROM `users` ORDER BY `created_at` ASC;",
+			result: "SELECT `users`.* FROM `users` ORDER BY `users`.`created_at` ASC;",
 			query:  query.SortAsc("created_at"),
 		},
 		{
-			result: "SELECT * FROM `users` ORDER BY `created_at` ASC, `id` DESC;",
+			result: "SELECT `users`.* FROM `users` ORDER BY `users`.`created_at` ASC, `users`.`id` DESC;",
 			query:  query.SortAsc("created_at").SortDesc("id"),
 		},
 		{
-			result: "SELECT * FROM `users` LIMIT 10 OFFSET 10;",
+			result: "SELECT `users`.* FROM `users` LIMIT 10 OFFSET 10;",
 			query:  query.Offset(10).Limit(10),
 		},
 		{
-			result: "SELECT * FROM `users` FOR UPDATE;",
+			result: "SELECT `users`.* FROM `users` FOR UPDATE;",
 			query:  rel.From("users").Lock("FOR UPDATE"),
 		},
 	}
@@ -123,7 +127,7 @@ func TestQuery_Build_ordinal(t *testing.T) {
 		query  rel.Query
 	}{
 		{
-			result: "SELECT * FROM \"users\";",
+			result: "SELECT \"users\".* FROM \"users\";",
 			query:  query,
 		},
 		{
@@ -131,49 +135,49 @@ func TestQuery_Build_ordinal(t *testing.T) {
 			query:  query.Select("users.*"),
 		},
 		{
-			result: "SELECT \"id\",\"name\" FROM \"users\";",
+			result: "SELECT \"users\".\"id\",\"users\".\"name\" FROM \"users\";",
 			query:  query.Select("id", "name"),
 		},
 		{
-			result: "SELECT \"id\" AS \"user_id\",\"name\" FROM \"users\";",
+			result: "SELECT \"users\".\"id\" AS \"user_id\",\"users\".\"name\" FROM \"users\";",
 			query:  query.Select("id as user_id", "name"),
 		},
 		{
-			result: "SELECT \"id\" AS \"user_id\",\"name\" FROM \"users\";",
+			result: "SELECT \"users\".\"id\" AS \"user_id\",\"users\".\"name\" FROM \"users\";",
 			query:  query.Select("id AS user_id", "name"),
 		},
 		{
-			result: "SELECT * FROM \"users\" JOIN \"transactions\" ON \"transactions\".\"id\"=\"users\".\"transaction_id\";",
+			result: "SELECT \"users\".* FROM \"users\" JOIN \"transactions\" ON \"transactions\".\"id\"=\"users\".\"transaction_id\";",
 			query:  query.JoinOn("transactions", "transactions.id", "users.transaction_id"),
 		},
 		{
-			result: "SELECT * FROM \"users\" WHERE \"id\"=$1;",
+			result: "SELECT \"users\".* FROM \"users\" WHERE \"users\".\"id\"=$1;",
 			args:   []interface{}{10},
 			query:  query.Where(where.Eq("id", 10)),
 		},
 		{
-			result: "SELECT DISTINCT * FROM \"users\" GROUP BY \"type\" HAVING \"price\">$1;",
+			result: "SELECT DISTINCT \"users\".* FROM \"users\" GROUP BY \"users\".\"type\" HAVING \"users\".\"price\">$1;",
 			args:   []interface{}{1000},
 			query:  query.Distinct().Group("type").Having(where.Gt("price", 1000)),
 		},
 		{
-			result: "SELECT * FROM \"users\" JOIN \"transactions\" ON \"transactions\".\"id\"=\"users\".\"transaction_id\";",
+			result: "SELECT \"users\".* FROM \"users\" JOIN \"transactions\" ON \"transactions\".\"id\"=\"users\".\"transaction_id\";",
 			query:  query.JoinOn("transactions", "transactions.id", "users.transaction_id"),
 		},
 		{
-			result: "SELECT * FROM \"users\" ORDER BY \"created_at\" ASC;",
+			result: "SELECT \"users\".* FROM \"users\" ORDER BY \"users\".\"created_at\" ASC;",
 			query:  query.SortAsc("created_at"),
 		},
 		{
-			result: "SELECT * FROM \"users\" ORDER BY \"created_at\" ASC, \"id\" DESC;",
+			result: "SELECT \"users\".* FROM \"users\" ORDER BY \"users\".\"created_at\" ASC, \"users\".\"id\" DESC;",
 			query:  query.SortAsc("created_at").SortDesc("id"),
 		},
 		{
-			result: "SELECT * FROM \"users\" LIMIT 10 OFFSET 10;",
+			result: "SELECT \"users\".* FROM \"users\" LIMIT 10 OFFSET 10;",
 			query:  query.Offset(10).Limit(10),
 		},
 		{
-			result: "SELECT * FROM \"users\" FOR UPDATE;",
+			result: "SELECT \"users\".* FROM \"users\" FOR UPDATE;",
 			query:  rel.From("users").Lock("FOR UPDATE"),
 		},
 	}
@@ -211,6 +215,7 @@ func TestQuery_WriteSelect(t *testing.T) {
 	)
 
 	tests := []struct {
+		table       string
 		result      string
 		selectQuery rel.SelectQuery
 	}{
@@ -245,6 +250,11 @@ func TestQuery_WriteSelect(t *testing.T) {
 			result:      "SELECT SUM(`transactions`.`total`) AS `total`",
 			selectQuery: rel.SelectQuery{Fields: []string{"SUM(transactions.total) AS total"}},
 		},
+		{
+			table:       "transactions",
+			result:      "SELECT `transactions`.*",
+			selectQuery: rel.SelectQuery{Fields: []string{"*"}},
+		},
 	}
 
 	for _, test := range tests {
@@ -253,7 +263,7 @@ func TestQuery_WriteSelect(t *testing.T) {
 				buffer = bufferFactory.Create()
 			)
 
-			queryBuilder.WriteSelect(&buffer, test.selectQuery)
+			queryBuilder.WriteSelect(&buffer, test.table, test.selectQuery)
 			assert.Equal(t, test.result, buffer.String())
 		})
 	}
@@ -325,6 +335,7 @@ func TestQuery_WriteWhere(t *testing.T) {
 	tests := []struct {
 		result string
 		args   []interface{}
+		table  string
 		filter rel.FilterQuery
 	}{
 		{
@@ -345,7 +356,7 @@ func TestQuery_WriteWhere(t *testing.T) {
 				buffer = bufferFactory.Create()
 			)
 
-			queryBuilder.WriteWhere(&buffer, test.filter)
+			queryBuilder.WriteWhere(&buffer, test.table, test.filter)
 
 			assert.Equal(t, test.result, buffer.String())
 			assert.Equal(t, test.args, buffer.Arguments())
@@ -362,6 +373,7 @@ func TestQuery_WriteWhere_ordinal(t *testing.T) {
 	tests := []struct {
 		result string
 		args   []interface{}
+		table  string
 		filter rel.FilterQuery
 	}{
 		{
@@ -382,7 +394,7 @@ func TestQuery_WriteWhere_ordinal(t *testing.T) {
 				buffer = bufferFactory.Create()
 			)
 
-			queryBuilder.WriteWhere(&buffer, test.filter)
+			queryBuilder.WriteWhere(&buffer, test.table, test.filter)
 
 			assert.Equal(t, test.result, buffer.String())
 			assert.Equal(t, test.args, buffer.Arguments())
@@ -399,24 +411,25 @@ func TestQuery_WriteWhere_SubQuery(t *testing.T) {
 	tests := []struct {
 		result string
 		args   []interface{}
+		table  string
 		filter rel.FilterQuery
 	}{
 		{
-			result: " WHERE `field`=ANY(SELECT `field1` FROM `table2` WHERE `type`=?)",
+			result: " WHERE `field`=ANY(SELECT `table2`.`field1` FROM `table2` WHERE `table2`.`type`=?)",
 			args:   []interface{}{"value"},
 			filter: where.Eq("field", rel.Any(
 				rel.Select("field1").From("table2").Where(where.Eq("type", "value")),
 			)),
 		},
 		{
-			result: " WHERE `field`=(SELECT `field1` FROM `table2` WHERE `type`=?)",
+			result: " WHERE `field`=(SELECT `table2`.`field1` FROM `table2` WHERE `table2`.`type`=?)",
 			args:   []interface{}{"value"},
 			filter: where.Eq("field",
 				rel.Select("field1").From("table2").Where(where.Eq("type", "value")),
 			),
 		},
 		{
-			result: " WHERE `field1` IN (SELECT `field2` FROM `table2` WHERE `field3` IN (?,?))",
+			result: " WHERE `field1` IN (SELECT `table2`.`field2` FROM `table2` WHERE `table2`.`field3` IN (?,?))",
 			args:   []interface{}{"value1", "value2"},
 			filter: where.In("field1", rel.Select("field2").From("table2").Where(
 				where.InString("field3", []string{"value1", "value2"}),
@@ -430,7 +443,7 @@ func TestQuery_WriteWhere_SubQuery(t *testing.T) {
 				buffer = bufferFactory.Create()
 			)
 
-			queryBuilder.WriteWhere(&buffer, test.filter)
+			queryBuilder.WriteWhere(&buffer, test.table, test.filter)
 
 			assert.Equal(t, test.result, buffer.String())
 			assert.Equal(t, test.args, buffer.Arguments())
@@ -447,24 +460,25 @@ func TestQuery_WriteWhere_SubQuery_ordinal(t *testing.T) {
 	tests := []struct {
 		result string
 		args   []interface{}
+		table  string
 		filter rel.FilterQuery
 	}{
 		{
-			result: " WHERE \"field1\"=ANY(SELECT \"field2\" FROM \"table2\" WHERE \"type\"=$1)",
+			result: " WHERE \"field1\"=ANY(SELECT \"table2\".\"field2\" FROM \"table2\" WHERE \"table2\".\"type\"=$1)",
 			args:   []interface{}{"value"},
 			filter: where.Eq("field1", rel.Any(
 				rel.Select("field2").From("table2").Where(where.Eq("type", "value")),
 			)),
 		},
 		{
-			result: " WHERE \"field1\"=(SELECT \"field2\" FROM \"table2\" WHERE \"type\"=$1)",
+			result: " WHERE \"field1\"=(SELECT \"table2\".\"field2\" FROM \"table2\" WHERE \"table2\".\"type\"=$1)",
 			args:   []interface{}{"value"},
 			filter: where.Eq("field1",
 				rel.Select("field2").From("table2").Where(where.Eq("type", "value")),
 			),
 		},
 		{
-			result: " WHERE \"field1\" IN (SELECT \"field2\" FROM \"table2\" WHERE \"field3\" IN ($1,$2))",
+			result: " WHERE \"field1\" IN (SELECT \"table2\".\"field2\" FROM \"table2\" WHERE \"table2\".\"field3\" IN ($1,$2))",
 			args:   []interface{}{"value1", "value2"},
 			filter: where.In("field1",
 				rel.Select("field2").From("table2").Where(
@@ -480,7 +494,7 @@ func TestQuery_WriteWhere_SubQuery_ordinal(t *testing.T) {
 				buffer = bufferFactory.Create()
 			)
 
-			queryBuilder.WriteWhere(&buffer, test.filter)
+			queryBuilder.WriteWhere(&buffer, test.table, test.filter)
 
 			assert.Equal(t, test.result, buffer.String())
 			assert.Equal(t, test.args, buffer.Arguments())
@@ -496,14 +510,20 @@ func TestQuery_WriteGroupBy(t *testing.T) {
 
 	t.Run("single field", func(t *testing.T) {
 		buffer := bufferFactory.Create()
-		queryBuilder.WriteGroupBy(&buffer, []string{"city"})
+		queryBuilder.WriteGroupBy(&buffer, "", []string{"city"})
 		assert.Equal(t, " GROUP BY `city`", buffer.String())
 	})
 
 	t.Run("multiple fields", func(t *testing.T) {
 		buffer := bufferFactory.Create()
-		queryBuilder.WriteGroupBy(&buffer, []string{"city", "nation"})
+		queryBuilder.WriteGroupBy(&buffer, "", []string{"city", "nation"})
 		assert.Equal(t, " GROUP BY `city`,`nation`", buffer.String())
+	})
+
+	t.Run("multiple fields with table", func(t *testing.T) {
+		buffer := bufferFactory.Create()
+		queryBuilder.WriteGroupBy(&buffer, "table", []string{"city", "table2.nation"})
+		assert.Equal(t, " GROUP BY `table`.`city`,`table2`.`nation`", buffer.String())
 	})
 }
 
@@ -516,6 +536,7 @@ func TestQuery_WriteHaving(t *testing.T) {
 	tests := []struct {
 		result string
 		args   []interface{}
+		table  string
 		filter rel.FilterQuery
 	}{
 		{
@@ -540,7 +561,7 @@ func TestQuery_WriteHaving(t *testing.T) {
 				buffer = bufferFactory.Create()
 			)
 
-			queryBuilder.WriteHaving(&buffer, test.filter)
+			queryBuilder.WriteHaving(&buffer, test.table, test.filter)
 
 			assert.Equal(t, test.result, buffer.String())
 			assert.Equal(t, test.args, buffer.Arguments())
@@ -557,6 +578,7 @@ func TestQuery_WriteHaving_ordinal(t *testing.T) {
 	tests := []struct {
 		result string
 		args   []interface{}
+		table  string
 		filter rel.FilterQuery
 	}{
 		{
@@ -577,7 +599,7 @@ func TestQuery_WriteHaving_ordinal(t *testing.T) {
 				buffer = bufferFactory.Create()
 			)
 
-			queryBuilder.WriteHaving(&buffer, test.filter)
+			queryBuilder.WriteHaving(&buffer, test.table, test.filter)
 
 			assert.Equal(t, test.result, buffer.String())
 			assert.Equal(t, test.args, buffer.Arguments())
@@ -593,15 +615,20 @@ func TestQuery_WriteOrderBy(t *testing.T) {
 
 	t.Run("single sort", func(t *testing.T) {
 		buffer := bufferFactory.Create()
-		queryBuilder.WriteOrderBy(&buffer, []rel.SortQuery{sort.Asc("name")})
+		queryBuilder.WriteOrderBy(&buffer, "", []rel.SortQuery{sort.Asc("name")})
 		assert.Equal(t, " ORDER BY `name` ASC", buffer.String())
 	})
 
 	t.Run("multiple sorts", func(t *testing.T) {
 		buffer := bufferFactory.Create()
-		queryBuilder.WriteOrderBy(&buffer, []rel.SortQuery{sort.Asc("name"), sort.Desc("created_at")})
+		queryBuilder.WriteOrderBy(&buffer, "", []rel.SortQuery{sort.Asc("name"), sort.Desc("created_at")})
 		assert.Equal(t, " ORDER BY `name` ASC, `created_at` DESC", buffer.String())
+	})
 
+	t.Run("multiple sorts with table", func(t *testing.T) {
+		buffer := bufferFactory.Create()
+		queryBuilder.WriteOrderBy(&buffer, "table", []rel.SortQuery{sort.Asc("name"), sort.Desc("table2.created_at")})
+		assert.Equal(t, " ORDER BY `table`.`name` ASC, `table2`.`created_at` DESC", buffer.String())
 	})
 }
 

--- a/builder/update.go
+++ b/builder/update.go
@@ -51,7 +51,7 @@ func (u Update) Build(table string, primaryField string, mutates map[string]rel.
 
 	if !filter.None() {
 		buffer.WriteString(" WHERE ")
-		u.Filter.Write(&buffer, filter, u.Query)
+		u.Filter.Write(&buffer, "", filter, u.Query)
 	}
 
 	buffer.WriteString(";")

--- a/builder/update.go
+++ b/builder/update.go
@@ -51,7 +51,7 @@ func (u Update) Build(table string, primaryField string, mutates map[string]rel.
 
 	if !filter.None() {
 		buffer.WriteString(" WHERE ")
-		u.Filter.Write(&buffer, "", filter, u.Query)
+		u.Filter.Write(&buffer, table, filter, u.Query)
 	}
 
 	buffer.WriteString(";")

--- a/builder/update_test.go
+++ b/builder/update_test.go
@@ -31,7 +31,7 @@ func TestUpdate_Build(t *testing.T) {
 	assert.ElementsMatch(t, []interface{}{"foo", 10, true}, qargs)
 
 	qs, qargs = updateBuilder.Build("users", "id", mutates, where.Eq("id", 1))
-	assert.Regexp(t, fmt.Sprint("UPDATE `users` SET `", `\w*`, "`=", `\?`, ",`", `\w*`, "`=", `\?`, ",`", `\w*`, "`=", `\?`, " WHERE `id`=", `\?`, ";"), qs)
+	assert.Regexp(t, fmt.Sprint("UPDATE `users` SET `", `\w*`, "`=", `\?`, ",`", `\w*`, "`=", `\?`, ",`", `\w*`, "`=", `\?`, " WHERE `users`.`id`=", `\?`, ";"), qs)
 	assert.ElementsMatch(t, []interface{}{"foo", 10, true, 1}, qargs)
 }
 
@@ -56,7 +56,7 @@ func TestUpdate_Build_ordinal(t *testing.T) {
 	assert.ElementsMatch(t, []interface{}{"foo", 10, true}, args)
 
 	qs, args = updateBuilder.Build("users", "id", mutates, where.Eq("id", 1))
-	assert.Regexp(t, `UPDATE "users" SET "\w*"=\$1,"\w*"=\$2,"\w*"=\$3 WHERE "id"=\$4;`, qs)
+	assert.Regexp(t, `UPDATE "users" SET "\w*"=\$1,"\w*"=\$2,"\w*"=\$3 WHERE "users"."id"=\$4;`, qs)
 	assert.ElementsMatch(t, []interface{}{"foo", 10, true, 1}, args)
 }
 


### PR DESCRIPTION
It was larger change than I expected initially but to me it looks like it's safest way to fix go-rel/rel#233