### PR TITLE
support IN clause with empty values in MySQL

### DIFF
--- a/builder/filter.go
+++ b/builder/filter.go
@@ -112,15 +112,23 @@ func (f Filter) BuildInclusion(buffer *Buffer, table string, filter rel.FilterQu
 		values = filter.Value.([]interface{})
 	)
 
-	buffer.WriteField(table, filter.Field)
-
-	if filter.Type == rel.FilterInOp {
-		buffer.WriteString(" IN ")
+	if len(values) == 0 {
+		if filter.Type == rel.FilterInOp {
+			buffer.WriteString("1=0")
+		} else {
+			buffer.WriteString("1=1")
+		}
 	} else {
-		buffer.WriteString(" NOT IN ")
-	}
+		buffer.WriteField(table, filter.Field)
 
-	f.buildInclusionValues(buffer, values, queryWriter)
+		if filter.Type == rel.FilterInOp {
+			buffer.WriteString(" IN ")
+		} else {
+			buffer.WriteString(" NOT IN ")
+		}
+
+		f.buildInclusionValues(buffer, values, queryWriter)
+	}
 }
 
 func (f Filter) buildInclusionValues(buffer *Buffer, values []interface{}, queryWriter QueryWriter) {

--- a/builder/filter_test.go
+++ b/builder/filter_test.go
@@ -78,6 +78,12 @@ func TestFilter_Write(t *testing.T) {
 			filter: where.In("field", "value1", "value2", "value3"),
 		},
 		{
+			result: "1=0",
+			args:   nil,
+			filter: where.In("field", []interface{}{}...),
+		},
+
+		{
 			result: "`field` NOT IN (?)",
 			args:   []interface{}{"value1"},
 			filter: where.Nin("field", "value1"),
@@ -91,6 +97,11 @@ func TestFilter_Write(t *testing.T) {
 			result: "`field` NOT IN (?,?,?)",
 			args:   []interface{}{"value1", "value2", "value3"},
 			filter: where.Nin("field", "value1", "value2", "value3"),
+		},
+		{
+			result: "1=1",
+			args:   nil,
+			filter: where.Nin("field", []interface{}{}...),
 		},
 		{
 			result: "`field` LIKE ?",


### PR DESCRIPTION
In MySQL, `IN` clause with empty values causes a syntax error.
This PR replaces an empty-valued `IN` clause with `1=0` (or `1=1` for a `NOT IN` clause).

see
- https://github.com/typeorm/typeorm/issues/2195
- https://github.com/typeorm/typeorm/pull/6887