### PR TITLE
Fixed the construction of query for tables with schema

### DIFF
--- a/builder/buffer.go
+++ b/builder/buffer.go
@@ -140,10 +140,8 @@ func (b Buffer) escape(table, value string) string {
 	}
 
 	if value == "*" {
-		return escaped_table + ".*"
-	}
-
-	if len(value) > 0 && value[0] == UnescapeCharacter {
+		escapedValue = escaped_table + ".*"
+	} else if len(value) > 0 && value[0] == UnescapeCharacter {
 		escapedValue = value[1:]
 	} else if _, err := strconv.Atoi(value); err == nil {
 		escapedValue = value

--- a/builder/buffer.go
+++ b/builder/buffer.go
@@ -115,11 +115,25 @@ func (b *Buffer) WriteEscape(value string) {
 }
 
 func (b Buffer) escape(table, value string) string {
+	var escaped_table string
+	if table != "" {
+		parts := strings.Split(table, ".")
+		if len(parts) != 1 {
+			for i, part := range parts {
+				part = strings.TrimSpace(part)
+				parts[i] = b.Quoter.ID(part)
+			}
+			escaped_table = strings.Join(parts, ".")
+		} else {
+			escaped_table = b.Quoter.ID(table)
+		}
+	}
+
 	if value == "*" {
 		if table == "" {
 			return value
 		}
-		return b.Quoter.ID(table) + ".*"
+		return escaped_table + ".*"
 	}
 
 	key := escapeCacheKey{table: table, value: value, quoter: b.Quoter}
@@ -138,9 +152,6 @@ func (b Buffer) escape(table, value string) string {
 		escapedValue = value[:start+1] + b.escape(table, value[start+1:end]) + value[end:]
 	} else {
 		parts := strings.Split(value, ".")
-		if len(parts) == 1 && table != "" {
-			parts = []string{table, parts[0]}
-		}
 		for i, part := range parts {
 			part = strings.TrimSpace(part)
 			if part == "*" && i == len(parts)-1 {
@@ -148,7 +159,11 @@ func (b Buffer) escape(table, value string) string {
 			}
 			parts[i] = b.Quoter.ID(part)
 		}
-		escapedValue = strings.Join(parts, ".")
+		result := strings.Join(parts, ".")
+		if len(parts) == 1 && table != "" {
+			result = escaped_table + "." + result
+		}
+		escapedValue = result
 	}
 
 	escapeCache.Store(key, escapedValue)

--- a/builder/buffer.go
+++ b/builder/buffer.go
@@ -115,6 +115,10 @@ func (b *Buffer) WriteEscape(value string) {
 }
 
 func (b Buffer) escape(table, value string) string {
+	if table == "" && value == "*" {
+		return value
+	}
+
 	key := escapeCacheKey{table: table, value: value, quoter: b.Quoter}
 	escapedValue, ok := escapeCache.Load(key)
 	if ok {
@@ -136,9 +140,6 @@ func (b Buffer) escape(table, value string) string {
 	}
 
 	if value == "*" {
-		if table == "" {
-			return value
-		}
 		return escaped_table + ".*"
 	}
 

--- a/builder/buffer_test.go
+++ b/builder/buffer_test.go
@@ -43,6 +43,11 @@ func TestBuffer_escape(t *testing.T) {
 			result: "[user].*",
 		},
 		{
+			table:  "user.user",
+			field:  "*",
+			result: "[user].[user].*",
+		},
+		{
 			table:  "user",
 			field:  "address as home_address",
 			result: "[user].[address] AS [home_address]",


### PR DESCRIPTION
Hi!

There was an issue with querying the database with the schema in the table name, i.e. `select * from user.user where id=$1`. I expected that the full table name with schema would deconstructed. However,t he generator gave me such result:
 `SELECT "users.users".* FROM "users"."users" WHERE "users.users"."id"=$1 LIMIT 1;`

The table name for the FROM clause was constructed as expected, however the `escape` function does not deconstruct the `table` value at all.

As a result, the query failed, with following error: `pq: missing FROM-clause entry for table "users.users"`
To fix this I added a small patch that deconstructs the table name for all queries with the table value set. 