### PR TITLE
support filtering table definitions

### DIFF
--- a/builder/table.go
+++ b/builder/table.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"log"
 	"strconv"
 
 	"github.com/go-rel/rel"
@@ -245,6 +246,8 @@ func (t Table) definitions(table rel.Table) []rel.TableDefinition {
 	for _, def := range table.Definitions {
 		if t.DefinitionFilter(table, def) {
 			result = append(result, def)
+		} else {
+			log.Print("[REL] An unsupported table definition has been excluded")
 		}
 	}
 

--- a/builder/table.go
+++ b/builder/table.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ColumnMapper func(*rel.Column) (string, int, int)
-type DefinitionFilter func(table rel.Table, def rel.TableDefinition) (bool, string)
+type DefinitionFilter func(table rel.Table, def rel.TableDefinition) bool
 
 // Table builder.
 type Table struct {
@@ -244,12 +244,10 @@ func (t Table) definitions(table rel.Table) []rel.TableDefinition {
 	result := []rel.TableDefinition{}
 
 	for _, def := range table.Definitions {
-		ok, reason := t.DefinitionFilter(table, def)
-
-		if ok {
+		if t.DefinitionFilter(table, def) {
 			result = append(result, def)
 		} else {
-			log.Print("[REL] An unsupported table definition has been excluded: " + reason)
+			log.Printf("[REL] An unsupported table definition has been excluded: %T", def)
 		}
 	}
 

--- a/builder/table.go
+++ b/builder/table.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ColumnMapper func(*rel.Column) (string, int, int)
-type DefinitionFilter func(table rel.Table, def rel.TableDefinition) bool
+type DefinitionFilter func(table rel.Table, def rel.TableDefinition) (bool, string)
 
 // Table builder.
 type Table struct {
@@ -244,10 +244,12 @@ func (t Table) definitions(table rel.Table) []rel.TableDefinition {
 	result := []rel.TableDefinition{}
 
 	for _, def := range table.Definitions {
-		if t.DefinitionFilter(table, def) {
+		ok, reason := t.DefinitionFilter(table, def)
+
+		if ok {
 			result = append(result, def)
 		} else {
-			log.Print("[REL] An unsupported table definition has been excluded")
+			log.Print("[REL] An unsupported table definition has been excluded: " + reason)
 		}
 	}
 

--- a/builder/table.go
+++ b/builder/table.go
@@ -38,7 +38,7 @@ func (t Table) Build(table rel.Table) string {
 
 // WriteCreateTable query to buffer.
 func (t Table) WriteCreateTable(buffer *Buffer, table rel.Table) {
-	defs := t.filterDefinition(table)
+	defs := t.definitions(table)
 
 	buffer.WriteString("CREATE TABLE ")
 
@@ -72,7 +72,7 @@ func (t Table) WriteCreateTable(buffer *Buffer, table rel.Table) {
 
 // WriteAlterTable query to buffer.
 func (t Table) WriteAlterTable(buffer *Buffer, table rel.Table) {
-	defs := t.filterDefinition(table)
+	defs := t.definitions(table)
 
 	for _, def := range defs {
 		buffer.WriteString("ALTER TABLE ")
@@ -235,7 +235,7 @@ func (t Table) WriteOptions(buffer *Buffer, options string) {
 	buffer.WriteString(options)
 }
 
-func (t Table) filterDefinition(table rel.Table) []rel.TableDefinition {
+func (t Table) definitions(table rel.Table) []rel.TableDefinition {
 	if t.DefinitionFilter == nil {
 		return table.Definitions
 	}

--- a/builder/table.go
+++ b/builder/table.go
@@ -236,10 +236,14 @@ func (t Table) WriteOptions(buffer *Buffer, options string) {
 }
 
 func (t Table) filterDefinition(table rel.Table) []rel.TableDefinition {
+	if t.DefinitionFilter == nil {
+		return table.Definitions
+	}
+
 	result := []rel.TableDefinition{}
 
 	for _, def := range table.Definitions {
-		if t.DefinitionFilter == nil || t.DefinitionFilter(table, def) {
+		if t.DefinitionFilter(table, def) {
 			result = append(result, def)
 		}
 	}

--- a/builder/table.go
+++ b/builder/table.go
@@ -38,7 +38,7 @@ func (t Table) Build(table rel.Table) string {
 
 // WriteCreateTable query to buffer.
 func (t Table) WriteCreateTable(buffer *Buffer, table rel.Table) {
-	defs := t.filterTableDefinition(table, table.Definitions)
+	defs := t.filterDefinition(table)
 
 	buffer.WriteString("CREATE TABLE ")
 
@@ -72,7 +72,7 @@ func (t Table) WriteCreateTable(buffer *Buffer, table rel.Table) {
 
 // WriteAlterTable query to buffer.
 func (t Table) WriteAlterTable(buffer *Buffer, table rel.Table) {
-	defs := t.filterTableDefinition(table, table.Definitions)
+	defs := t.filterDefinition(table)
 
 	for _, def := range defs {
 		buffer.WriteString("ALTER TABLE ")
@@ -235,10 +235,10 @@ func (t Table) WriteOptions(buffer *Buffer, options string) {
 	buffer.WriteString(options)
 }
 
-func (t Table) filterTableDefinition(table rel.Table, defs []rel.TableDefinition) []rel.TableDefinition {
+func (t Table) filterDefinition(table rel.Table) []rel.TableDefinition {
 	result := []rel.TableDefinition{}
 
-	for _, def := range defs {
+	for _, def := range table.Definitions {
 		if t.DefinitionFilter == nil || t.DefinitionFilter(table, def) {
 			result = append(result, def)
 		}

--- a/builder/table_test.go
+++ b/builder/table_test.go
@@ -136,15 +136,15 @@ func TestTable_Build(t *testing.T) {
 
 func TestTable_BuildWithDefinitionFilter(t *testing.T) {
 	var (
-		definitionFilter = func(table rel.Table, def rel.TableDefinition) (bool, string) {
+		definitionFilter = func(table rel.Table, def rel.TableDefinition) bool {
 			_, ok := def.(rel.Key)
 			// https://www.sqlite.org/omitted.html
 			// > Only the RENAME TABLE, ADD COLUMN, RENAME COLUMN, and DROP COLUMN variants of the ALTER TABLE command are supported.
 			if ok && table.Op == rel.SchemaAlter {
-				return false, "adapter does not support adding keys when modifying tables"
+				return false
 			}
 
-			return true, ""
+			return true
 		}
 		tableBuilder = Table{
 			BufferFactory:    BufferFactory{InlineValues: true, BoolTrueValue: "true", BoolFalseValue: "false", Quoter: Quote{IDPrefix: "`", IDSuffix: "`", IDSuffixEscapeChar: "`", ValueQuote: "'", ValueQuoteEscapeChar: "'"}},

--- a/builder/table_test.go
+++ b/builder/table_test.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"log"
 	"testing"
 	"time"
 
@@ -141,6 +142,8 @@ func TestTable_BuildWithDefinitionFilter(t *testing.T) {
 			// https://www.sqlite.org/omitted.html
 			// > Only the RENAME TABLE, ADD COLUMN, RENAME COLUMN, and DROP COLUMN variants of the ALTER TABLE command are supported.
 			if ok && table.Op == rel.SchemaAlter {
+				log.Print("[REL] Adapter does not support adding keys when modifying tables")
+
 				return false
 			}
 

--- a/builder/table_test.go
+++ b/builder/table_test.go
@@ -1,7 +1,6 @@
 package builder
 
 import (
-	"log"
 	"testing"
 	"time"
 
@@ -137,17 +136,15 @@ func TestTable_Build(t *testing.T) {
 
 func TestTable_BuildWithDefinitionFilter(t *testing.T) {
 	var (
-		definitionFilter = func(table rel.Table, def rel.TableDefinition) bool {
+		definitionFilter = func(table rel.Table, def rel.TableDefinition) (bool, string) {
 			_, ok := def.(rel.Key)
 			// https://www.sqlite.org/omitted.html
 			// > Only the RENAME TABLE, ADD COLUMN, RENAME COLUMN, and DROP COLUMN variants of the ALTER TABLE command are supported.
 			if ok && table.Op == rel.SchemaAlter {
-				log.Print("[REL] Adapter does not support adding keys when modifying tables")
-
-				return false
+				return false, "adapter does not support adding keys when modifying tables"
 			}
 
-			return true
+			return true, ""
 		}
 		tableBuilder = Table{
 			BufferFactory:    BufferFactory{InlineValues: true, BoolTrueValue: "true", BoolFalseValue: "false", Quoter: Quote{IDPrefix: "`", IDSuffix: "`", IDSuffixEscapeChar: "`", ValueQuote: "'", ValueQuoteEscapeChar: "'"}},

--- a/builder/table_test.go
+++ b/builder/table_test.go
@@ -137,13 +137,11 @@ func TestTable_Build(t *testing.T) {
 func TestTable_BuildWithDefinitionFilter(t *testing.T) {
 	var (
 		definitionFilter = func(table rel.Table, def rel.TableDefinition) bool {
-			switch def.(type) {
-			case rel.Key:
-				// https://www.sqlite.org/omitted.html
-				// > Only the RENAME TABLE, ADD COLUMN, RENAME COLUMN, and DROP COLUMN variants of the ALTER TABLE command are supported.
-				if table.Op == rel.SchemaAlter {
-					return false
-				}
+			_, ok := def.(rel.Key)
+			// https://www.sqlite.org/omitted.html
+			// > Only the RENAME TABLE, ADD COLUMN, RENAME COLUMN, and DROP COLUMN variants of the ALTER TABLE command are supported.
+			if ok && table.Op == rel.SchemaAlter {
+				return false
 			}
 
 			return true

--- a/builder/table_test.go
+++ b/builder/table_test.go
@@ -158,6 +158,19 @@ func TestTable_BuildWithDefinitionFilter(t *testing.T) {
 		table  rel.Table
 	}{
 		{
+			result: "ALTER TABLE `columns` ADD COLUMN `verified` BOOL;ALTER TABLE `columns` RENAME COLUMN `string` TO `name`;ALTER TABLE `columns` ;ALTER TABLE `columns` DROP COLUMN `blob`;",
+			table: rel.Table{
+				Op:   rel.SchemaAlter,
+				Name: "columns",
+				Definitions: []rel.TableDefinition{
+					rel.Column{Name: "verified", Type: rel.Bool, Op: rel.SchemaCreate},
+					rel.Column{Name: "string", Rename: "name", Op: rel.SchemaRename},
+					rel.Column{Name: "bool", Type: rel.Int, Op: rel.SchemaAlter},
+					rel.Column{Name: "blob", Op: rel.SchemaDrop},
+				},
+			},
+		},
+		{
 			result: "CREATE TABLE `columns` (`bool` BOOL NOT NULL DEFAULT false, `int` INT(11) UNSIGNED, `bigint` BIGINT(20) UNSIGNED, `float` FLOAT(24) UNSIGNED, `decimal` DECIMAL(6,2) UNSIGNED, `string` VARCHAR(144) UNIQUE, `text` TEXT(1000), `date` DATE, `datetime` DATETIME DEFAULT '2020-01-01 01:00:00', `time` TIME, `blob` blob, PRIMARY KEY (`int`), FOREIGN KEY (`int`, `string`) REFERENCES `products` (`id`, `name`) ON DELETE CASCADE ON UPDATE CASCADE, UNIQUE `date_unique` (`date`)) Engine=InnoDB;",
 			table: rel.Table{
 				Op:   rel.SchemaCreate,

--- a/builder/table_test.go
+++ b/builder/table_test.go
@@ -98,7 +98,7 @@ func TestTable_Build(t *testing.T) {
 				Op:   rel.SchemaAlter,
 				Name: "transactions",
 				Definitions: []rel.TableDefinition{
-					rel.Key{Op: rel.SchemaCreate, Columns: []string{"user_id"}, Type: rel.ForeignKey, Reference: rel.ForeignKeyReference{Table: "products", Columns: []string{"id", "name"}, OnDelete: "CASCADE", OnUpdate: "CASCADE"}},
+					rel.Key{Columns: []string{"user_id"}, Type: rel.ForeignKey, Reference: rel.ForeignKeyReference{Table: "products", Columns: []string{"id", "name"}, OnDelete: "CASCADE", OnUpdate: "CASCADE"}},
 				},
 			},
 		},

--- a/builder/table_test.go
+++ b/builder/table_test.go
@@ -158,19 +158,6 @@ func TestTable_BuildWithDefinitionFilter(t *testing.T) {
 		table  rel.Table
 	}{
 		{
-			result: "ALTER TABLE `columns` ADD COLUMN `verified` BOOL;ALTER TABLE `columns` RENAME COLUMN `string` TO `name`;ALTER TABLE `columns` ;ALTER TABLE `columns` DROP COLUMN `blob`;",
-			table: rel.Table{
-				Op:   rel.SchemaAlter,
-				Name: "columns",
-				Definitions: []rel.TableDefinition{
-					rel.Column{Name: "verified", Type: rel.Bool, Op: rel.SchemaCreate},
-					rel.Column{Name: "string", Rename: "name", Op: rel.SchemaRename},
-					rel.Column{Name: "bool", Type: rel.Int, Op: rel.SchemaAlter},
-					rel.Column{Name: "blob", Op: rel.SchemaDrop},
-				},
-			},
-		},
-		{
 			result: "CREATE TABLE `columns` (`bool` BOOL NOT NULL DEFAULT false, `int` INT(11) UNSIGNED, `bigint` BIGINT(20) UNSIGNED, `float` FLOAT(24) UNSIGNED, `decimal` DECIMAL(6,2) UNSIGNED, `string` VARCHAR(144) UNIQUE, `text` TEXT(1000), `date` DATE, `datetime` DATETIME DEFAULT '2020-01-01 01:00:00', `time` TIME, `blob` blob, PRIMARY KEY (`int`), FOREIGN KEY (`int`, `string`) REFERENCES `products` (`id`, `name`) ON DELETE CASCADE ON UPDATE CASCADE, UNIQUE `date_unique` (`date`)) Engine=InnoDB;",
 			table: rel.Table{
 				Op:   rel.SchemaCreate,
@@ -192,6 +179,19 @@ func TestTable_BuildWithDefinitionFilter(t *testing.T) {
 					rel.Key{Columns: []string{"date"}, Name: "date_unique", Type: rel.UniqueKey},
 				},
 				Options: "Engine=InnoDB",
+			},
+		},
+		{
+			result: "ALTER TABLE `columns` ADD COLUMN `verified` BOOL;ALTER TABLE `columns` RENAME COLUMN `string` TO `name`;ALTER TABLE `columns` ;ALTER TABLE `columns` DROP COLUMN `blob`;",
+			table: rel.Table{
+				Op:   rel.SchemaAlter,
+				Name: "columns",
+				Definitions: []rel.TableDefinition{
+					rel.Column{Name: "verified", Type: rel.Bool, Op: rel.SchemaCreate},
+					rel.Column{Name: "string", Rename: "name", Op: rel.SchemaRename},
+					rel.Column{Name: "bool", Type: rel.Int, Op: rel.SchemaAlter},
+					rel.Column{Name: "blob", Op: rel.SchemaDrop},
+				},
 			},
 		},
 		{


### PR DESCRIPTION
Added a mechanism to exclude unsupported table definitions, example for use with sqlite3 adapters that do not support `ADD CONSTRAINT` when changing the table schema.