### PR TITLE
Allow to specify for adapter if it supports schema for table names

### DIFF
--- a/builder/buffer.go
+++ b/builder/buffer.go
@@ -30,6 +30,7 @@ type Buffer struct {
 	Quoter              Quoter
 	ValueConverter      driver.ValueConverter
 	ArgumentPlaceholder string
+	AllowTableSchema    bool
 	ArgumentOrdinal     bool
 	InlineValues        bool
 	BoolTrueValue       string
@@ -47,7 +48,7 @@ func (b *Buffer) WriteValue(value any) {
 	}
 
 	// Detect float bits to not lose precision after converting to float64
-	var floatBits = 64
+	floatBits := 64
 	if value != nil && reflect.TypeOf(value).Kind() == reflect.Float32 {
 		floatBits = 32
 	}
@@ -109,6 +110,11 @@ func (b *Buffer) WriteField(table, field string) {
 	b.WriteString(b.escape(table, field))
 }
 
+// WriteTable writes table name.
+func (b *Buffer) WriteTable(table string) {
+	b.WriteString(b.escape(table, ""))
+}
+
 // WriteEscape string.
 func (b *Buffer) WriteEscape(value string) {
 	b.WriteString(b.escape("", value))
@@ -127,7 +133,7 @@ func (b Buffer) escape(table, value string) string {
 
 	var escaped_table string
 	if table != "" {
-		if strings.IndexByte(table, '.') >= 0 {
+		if b.AllowTableSchema && strings.IndexByte(table, '.') >= 0 {
 			parts := strings.Split(table, ".")
 			for i, part := range parts {
 				part = strings.TrimSpace(part)
@@ -135,11 +141,13 @@ func (b Buffer) escape(table, value string) string {
 			}
 			escaped_table = strings.Join(parts, ".")
 		} else {
-			escaped_table = b.Quoter.ID(table)
+			escaped_table = b.Quoter.ID(strings.ReplaceAll(table, ".", "_"))
 		}
 	}
 
-	if value == "*" {
+	if value == "" {
+		escapedValue = escaped_table
+	} else if value == "*" {
 		escapedValue = escaped_table + ".*"
 	} else if len(value) > 0 && value[0] == UnescapeCharacter {
 		escapedValue = value[1:]
@@ -193,6 +201,7 @@ func (b *Buffer) Reset() {
 type BufferFactory struct {
 	Quoter              Quoter
 	ValueConverter      driver.ValueConverter
+	AllowTableSchema    bool
 	ArgumentPlaceholder string
 	ArgumentOrdinal     bool
 	InlineValues        bool
@@ -208,6 +217,7 @@ func (bf BufferFactory) Create() Buffer {
 	return Buffer{
 		Quoter:              bf.Quoter,
 		ValueConverter:      conv,
+		AllowTableSchema:    bf.AllowTableSchema,
 		ArgumentPlaceholder: bf.ArgumentPlaceholder,
 		ArgumentOrdinal:     bf.ArgumentOrdinal,
 		InlineValues:        bf.InlineValues,

--- a/builder/buffer_test.go
+++ b/builder/buffer_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestBuffer_escape(t *testing.T) {
-	buffer := Buffer{Quoter: Quote{IDPrefix: "[", IDSuffix: "]"}}
+	buffer := Buffer{AllowTableSchema: true, Quoter: Quote{IDPrefix: "[", IDSuffix: "]"}}
 
 	tests := []struct {
 		table  string
@@ -23,6 +23,10 @@ func TestBuffer_escape(t *testing.T) {
 		{
 			field:  "user.address as home_address",
 			result: "[user].[address] AS [home_address]",
+		},
+		{
+			field:  "public.user.address as home_address",
+			result: "[public].[user].[address] AS [home_address]",
 		},
 		{
 			table:  "ignored",
@@ -70,9 +74,7 @@ func TestBuffer_escape(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.result, func(t *testing.T) {
-			var (
-				result = buffer.escape(test.table, test.field)
-			)
+			result := buffer.escape(test.table, test.field)
 
 			assert.Equal(t, test.result, result)
 		})

--- a/builder/delete.go
+++ b/builder/delete.go
@@ -13,12 +13,10 @@ type Delete struct {
 
 // Build SQL query and its arguments.
 func (ds Delete) Build(table string, filter rel.FilterQuery) (string, []any) {
-	var (
-		buffer = ds.BufferFactory.Create()
-	)
+	buffer := ds.BufferFactory.Create()
 
 	buffer.WriteString("DELETE FROM ")
-	buffer.WriteEscape(table)
+	buffer.WriteTable(table)
 
 	if !filter.None() {
 		buffer.WriteString(" WHERE ")

--- a/builder/delete_test.go
+++ b/builder/delete_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestDelete_Builder(t *testing.T) {
 	var (
-		bufferFactory = BufferFactory{ArgumentPlaceholder: "?", Quoter: Quote{IDPrefix: "`", IDSuffix: "`", IDSuffixEscapeChar: "`", ValueQuote: "'", ValueQuoteEscapeChar: "'"}}
+		bufferFactory = BufferFactory{AllowTableSchema: true, ArgumentPlaceholder: "?", Quoter: Quote{IDPrefix: "`", IDSuffix: "`", IDSuffixEscapeChar: "`", ValueQuote: "'", ValueQuoteEscapeChar: "'"}}
 		filter        = Filter{}
 		deleteBuilder = Delete{
 			BufferFactory: bufferFactory,
@@ -22,8 +22,8 @@ func TestDelete_Builder(t *testing.T) {
 	assert.Equal(t, "DELETE FROM `users`;", qs)
 	assert.Equal(t, []any(nil), args)
 
-	qs, args = deleteBuilder.Build("users", where.Eq("id", 1))
-	assert.Equal(t, "DELETE FROM `users` WHERE `users`.`id`=?;", qs)
+	qs, args = deleteBuilder.Build("public.users", where.Eq("id", 1))
+	assert.Equal(t, "DELETE FROM `public`.`users` WHERE `public`.`users`.`id`=?;", qs)
 	assert.Equal(t, []any{1}, args)
 }
 
@@ -42,7 +42,7 @@ func TestDelete_Builder_ordinal(t *testing.T) {
 	assert.Equal(t, "DELETE FROM \"users\";", qs)
 	assert.Equal(t, []any(nil), args)
 
-	qs, args = deleteBuilder.Build("users", where.Eq("id", 1))
-	assert.Equal(t, "DELETE FROM \"users\" WHERE \"users\".\"id\"=$1;", qs)
+	qs, args = deleteBuilder.Build("public.users", where.Eq("id", 1))
+	assert.Equal(t, "DELETE FROM \"public_users\" WHERE \"public_users\".\"id\"=$1;", qs)
 	assert.Equal(t, []any{1}, args)
 }

--- a/builder/index.go
+++ b/builder/index.go
@@ -46,7 +46,7 @@ func (i Index) WriteCreateIndex(buffer *Buffer, index rel.Index) {
 
 	buffer.WriteEscape(index.Name)
 	buffer.WriteString(" ON ")
-	buffer.WriteEscape(index.Table)
+	buffer.WriteTable(index.Table)
 
 	buffer.WriteString(" (")
 	for n, col := range index.Columns {
@@ -78,7 +78,7 @@ func (i Index) WriteDropIndex(buffer *Buffer, index rel.Index) {
 
 	if i.DropIndexOnTable {
 		buffer.WriteString(" ON ")
-		buffer.WriteEscape(index.Table)
+		buffer.WriteTable(index.Table)
 	}
 }
 

--- a/builder/index_test.go
+++ b/builder/index_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestIndex_Build(t *testing.T) {
 	var (
-		bufferFactory = BufferFactory{ArgumentPlaceholder: "?", InlineValues: true, BoolTrueValue: "true", BoolFalseValue: "false", Quoter: Quote{IDPrefix: "`", IDSuffix: "`", IDSuffixEscapeChar: "`", ValueQuote: "'", ValueQuoteEscapeChar: "'"}}
+		bufferFactory = BufferFactory{AllowTableSchema: true, ArgumentPlaceholder: "?", InlineValues: true, BoolTrueValue: "true", BoolFalseValue: "false", Quoter: Quote{IDPrefix: "`", IDSuffix: "`", IDSuffixEscapeChar: "`", ValueQuote: "'", ValueQuoteEscapeChar: "'"}}
 		filter        = Filter{}
 		indexBuilder  = Index{
 			BufferFactory:    bufferFactory,
@@ -118,6 +118,16 @@ func TestIndex_Build(t *testing.T) {
 				Name:     "index",
 				Table:    "table",
 				Optional: true,
+			},
+		},
+		{
+			result: "CREATE INDEX IF NOT EXISTS `index` ON `schema`.`table` (`column1`);",
+			index: rel.Index{
+				Op:       rel.SchemaCreate,
+				Table:    "schema.table",
+				Name:     "index",
+				Optional: true,
+				Columns:  []string{"column1"},
 			},
 		},
 	}

--- a/builder/insert.go
+++ b/builder/insert.go
@@ -14,9 +14,7 @@ type Insert struct {
 
 // Build sql query and its arguments.
 func (i Insert) Build(table string, primaryField string, mutates map[string]rel.Mutate, onConflict rel.OnConflict) (string, []any) {
-	var (
-		buffer = i.BufferFactory.Create()
-	)
+	buffer := i.BufferFactory.Create()
 
 	i.WriteInsertInto(&buffer, table)
 	i.WriteValues(&buffer, mutates)
@@ -30,13 +28,11 @@ func (i Insert) Build(table string, primaryField string, mutates map[string]rel.
 
 func (i Insert) WriteInsertInto(buffer *Buffer, table string) {
 	buffer.WriteString("INSERT INTO ")
-	buffer.WriteEscape(table)
+	buffer.WriteTable(table)
 }
 
 func (i Insert) WriteValues(buffer *Buffer, mutates map[string]rel.Mutate) {
-	var (
-		count = len(mutates)
-	)
+	count := len(mutates)
 
 	if count == 0 && i.InsertDefaultValues {
 		buffer.WriteString(" DEFAULT VALUES")

--- a/builder/insert_all.go
+++ b/builder/insert_all.go
@@ -13,9 +13,7 @@ type InsertAll struct {
 
 // Build SQL string and its arguments.
 func (ia InsertAll) Build(table string, primaryField string, fields []string, bulkMutates []map[string]rel.Mutate, onConflict rel.OnConflict) (string, []any) {
-	var (
-		buffer = ia.BufferFactory.Create()
-	)
+	buffer := ia.BufferFactory.Create()
 
 	ia.WriteInsertInto(&buffer, table)
 	ia.WriteValues(&buffer, fields, bulkMutates)
@@ -28,7 +26,7 @@ func (ia InsertAll) Build(table string, primaryField string, fields []string, bu
 
 func (ia InsertAll) WriteInsertInto(buffer *Buffer, table string) {
 	buffer.WriteString("INSERT INTO ")
-	buffer.WriteEscape(table)
+	buffer.WriteTable(table)
 }
 
 func (ia InsertAll) WriteValues(buffer *Buffer, fields []string, bulkMutates []map[string]rel.Mutate) {

--- a/builder/query.go
+++ b/builder/query.go
@@ -19,9 +19,7 @@ type Query struct {
 
 // Build SQL string and it arguments.
 func (q Query) Build(query rel.Query) (string, []any) {
-	var (
-		buffer = q.BufferFactory.Create()
-	)
+	buffer := q.BufferFactory.Create()
 
 	q.Write(&buffer, query)
 
@@ -96,7 +94,7 @@ func (q Query) WriteQuery(buffer *Buffer, query rel.Query) {
 // WriteFrom SQL to buffer.
 func (q Query) WriteFrom(buffer *Buffer, table string) {
 	buffer.WriteString(" FROM ")
-	buffer.WriteEscape(table)
+	buffer.WriteTable(table)
 }
 
 // WriteJoin SQL to buffer.
@@ -122,7 +120,7 @@ func (q Query) WriteJoin(buffer *Buffer, table string, joins []rel.JoinQuery) {
 		buffer.WriteByte(' ')
 
 		if join.Table != "" {
-			buffer.WriteEscape(join.Table)
+			buffer.WriteTable(join.Table)
 			buffer.WriteString(" ON ")
 			buffer.WriteEscape(from)
 			buffer.WriteString("=")
@@ -173,9 +171,7 @@ func (q Query) WriteHaving(buffer *Buffer, table string, filter rel.FilterQuery)
 
 // WriteOrderBy SQL to buffer.
 func (q Query) WriteOrderBy(buffer *Buffer, table string, orders []rel.SortQuery) {
-	var (
-		length = len(orders)
-	)
+	length := len(orders)
 
 	if length == 0 {
 		return

--- a/builder/update.go
+++ b/builder/update.go
@@ -13,12 +13,10 @@ type Update struct {
 
 // Build SQL string and it arguments.
 func (u Update) Build(table string, primaryField string, mutates map[string]rel.Mutate, filter rel.FilterQuery) (string, []any) {
-	var (
-		buffer = u.BufferFactory.Create()
-	)
+	buffer := u.BufferFactory.Create()
 
 	buffer.WriteString("UPDATE ")
-	buffer.WriteEscape(table)
+	buffer.WriteTable(table)
 	buffer.WriteString(" SET ")
 
 	i := 0


### PR DESCRIPTION
Fixes go-rel/rel#222

If adapter does not support schemas it will generate table names `schema_table` instead

After this I will update all adapters
