### PR TITLE
Allow for adapters to implement custom column option mappers

### DIFF
--- a/builder/table.go
+++ b/builder/table.go
@@ -8,17 +8,19 @@ import (
 )
 
 type (
-	ColumnMapper     func(*rel.Column) (string, int, int)
-	DropKeyMapper    func(rel.KeyType) string
-	DefinitionFilter func(table rel.Table, def rel.TableDefinition) bool
+	ColumnMapper        func(*rel.Column) (string, int, int)
+	ColumnOptionsMapper func(*rel.Column) string
+	DropKeyMapper       func(rel.KeyType) string
+	DefinitionFilter    func(table rel.Table, def rel.TableDefinition) bool
 )
 
 // Table builder.
 type Table struct {
-	BufferFactory    BufferFactory
-	ColumnMapper     ColumnMapper
-	DropKeyMapper    DropKeyMapper
-	DefinitionFilter DefinitionFilter
+	BufferFactory       BufferFactory
+	ColumnMapper        ColumnMapper
+	ColumnOptionsMapper ColumnOptionsMapper
+	DropKeyMapper       DropKeyMapper
+	DefinitionFilter    DefinitionFilter
 }
 
 // Build SQL query for table creation and modification.
@@ -158,20 +160,9 @@ func (t Table) WriteColumn(buffer *Buffer, column rel.Column) {
 		buffer.WriteByte(')')
 	}
 
-	if column.Unsigned {
-		buffer.WriteString(" UNSIGNED")
-	}
-
-	if column.Unique {
-		buffer.WriteString(" UNIQUE")
-	}
-
-	if column.Required {
-		buffer.WriteString(" NOT NULL")
-	}
-
-	if column.Primary {
-		buffer.WriteString(" PRIMARY KEY")
+	if opts := t.ColumnOptionsMapper(&column); opts != "" {
+		buffer.WriteByte(' ')
+		buffer.WriteString(opts)
 	}
 
 	if column.Default != nil {

--- a/builder/table_test.go
+++ b/builder/table_test.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -10,13 +11,12 @@ import (
 )
 
 func TestTable_Build(t *testing.T) {
-	var (
-		tableBuilder = Table{
-			BufferFactory: BufferFactory{InlineValues: true, BoolTrueValue: "true", BoolFalseValue: "false", Quoter: Quote{IDPrefix: "`", IDSuffix: "`", IDSuffixEscapeChar: "`", ValueQuote: "'", ValueQuoteEscapeChar: "'"}},
-			ColumnMapper:  sql.ColumnMapper,
-			DropKeyMapper: sql.DropKeyMapper,
-		}
-	)
+	tableBuilder := Table{
+		BufferFactory:       BufferFactory{InlineValues: true, BoolTrueValue: "true", BoolFalseValue: "false", Quoter: Quote{IDPrefix: "`", IDSuffix: "`", IDSuffixEscapeChar: "`", ValueQuote: "'", ValueQuoteEscapeChar: "'"}},
+		ColumnMapper:        sql.ColumnMapper,
+		ColumnOptionsMapper: sql.ColumnOptionsMapper,
+		DropKeyMapper:       sql.DropKeyMapper,
+	}
 
 	tests := []struct {
 		result string
@@ -158,9 +158,10 @@ func TestTable_BuildWithDefinitionFilter(t *testing.T) {
 			return true
 		}
 		tableBuilder = Table{
-			BufferFactory:    BufferFactory{InlineValues: true, BoolTrueValue: "true", BoolFalseValue: "false", Quoter: Quote{IDPrefix: "`", IDSuffix: "`", IDSuffixEscapeChar: "`", ValueQuote: "'", ValueQuoteEscapeChar: "'"}},
-			ColumnMapper:     sql.ColumnMapper,
-			DefinitionFilter: definitionFilter,
+			BufferFactory:       BufferFactory{InlineValues: true, BoolTrueValue: "true", BoolFalseValue: "false", Quoter: Quote{IDPrefix: "`", IDSuffix: "`", IDSuffixEscapeChar: "`", ValueQuote: "'", ValueQuoteEscapeChar: "'"}},
+			ColumnMapper:        sql.ColumnMapper,
+			ColumnOptionsMapper: sql.ColumnOptionsMapper,
+			DefinitionFilter:    definitionFilter,
 		}
 	)
 
@@ -212,6 +213,85 @@ func TestTable_BuildWithDefinitionFilter(t *testing.T) {
 				Name: "transactions",
 				Definitions: []rel.TableDefinition{
 					rel.Key{Op: rel.SchemaCreate, Columns: []string{"user_id"}, Type: rel.ForeignKey, Reference: rel.ForeignKeyReference{Table: "products", Columns: []string{"id", "name"}, OnDelete: "CASCADE", OnUpdate: "CASCADE"}},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.result, func(t *testing.T) {
+			assert.Equal(t, test.result, tableBuilder.Build(test.table))
+		})
+	}
+}
+
+func TestTable_BuildWithColumnMapper(t *testing.T) {
+	var (
+		columnMapper = func(column *rel.Column) (string, int, int) {
+			if column.Type == rel.ID || column.Type == rel.BigID {
+				return "INTEGER", 0, 0
+			}
+			return sql.ColumnMapper(column)
+		}
+
+		columnOptionsMapper = func(column *rel.Column) string {
+			var buffer strings.Builder
+
+			if column.Unique {
+				buffer.WriteString(" UNIQUE")
+			}
+
+			if column.Required {
+				buffer.WriteString(" NOT NULL")
+			}
+
+			if column.Primary {
+				buffer.WriteString(" PRIMARY KEY")
+				if column.Type == rel.ID || column.Type == rel.BigID {
+					buffer.WriteString(" AUTOINCREMENT")
+				}
+			}
+
+			buf := buffer.String()
+			if buf != "" {
+				buf = buf[1:]
+			}
+
+			return buf
+		}
+
+		tableBuilder = Table{
+			BufferFactory:       BufferFactory{InlineValues: true, BoolTrueValue: "true", BoolFalseValue: "false", Quoter: Quote{IDPrefix: "`", IDSuffix: "`", IDSuffixEscapeChar: "`", ValueQuote: "'", ValueQuoteEscapeChar: "'"}},
+			ColumnMapper:        columnMapper,
+			ColumnOptionsMapper: columnOptionsMapper,
+		}
+	)
+
+	tests := []struct {
+		result string
+		table  rel.Table
+	}{
+		{
+			result: "CREATE TABLE `columns` (`id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, `bigid` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, `bool` BOOL NOT NULL DEFAULT false, `int` INT(11), `bigint` BIGINT(20), `float` FLOAT(24), `decimal` DECIMAL(6,2), `string` VARCHAR(144) UNIQUE, `text` TEXT(1000), `date` DATE, `datetime` DATETIME DEFAULT '2020-01-01 01:00:00', `time` TIME, `blob` blob, FOREIGN KEY (`int`, `string`) REFERENCES `products` (`id`, `name`) ON DELETE CASCADE ON UPDATE CASCADE, UNIQUE `date_unique` (`date`));",
+			table: rel.Table{
+				Op:   rel.SchemaCreate,
+				Name: "columns",
+				Definitions: []rel.TableDefinition{
+					rel.Column{Name: "id", Type: rel.ID, Required: true, Primary: true},
+					rel.Column{Name: "bigid", Type: rel.BigID, Required: true, Primary: true},
+					rel.Column{Name: "bool", Type: rel.Bool, Required: true, Default: false},
+					rel.Column{Name: "int", Type: rel.Int, Limit: 11, Unsigned: true},
+					rel.Column{Name: "bigint", Type: rel.BigInt, Limit: 20, Unsigned: true},
+					rel.Column{Name: "float", Type: rel.Float, Precision: 24, Unsigned: true},
+					rel.Column{Name: "decimal", Type: rel.Decimal, Precision: 6, Scale: 2, Unsigned: true},
+					rel.Column{Name: "string", Type: rel.String, Limit: 144, Unique: true},
+					rel.Column{Name: "text", Type: rel.Text, Limit: 1000},
+					rel.Column{Name: "date", Type: rel.Date},
+					rel.Column{Name: "datetime", Type: rel.DateTime, Default: time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)},
+					rel.Column{Name: "time", Type: rel.Time},
+					rel.Column{Name: "blob", Type: "blob"},
+					rel.Key{Columns: []string{"int", "string"}, Type: rel.ForeignKey, Reference: rel.ForeignKeyReference{Table: "products", Columns: []string{"id", "name"}, OnDelete: "CASCADE", OnUpdate: "CASCADE"}},
+					rel.Key{Columns: []string{"date"}, Name: "date_unique", Type: rel.UniqueKey},
 				},
 			},
 		},

--- a/util.go
+++ b/util.go
@@ -72,6 +72,34 @@ func ColumnMapper(column *rel.Column) (string, int, int) {
 	return typ, m, n
 }
 
+// ColumnOptionsMapper function.
+func ColumnOptionsMapper(column *rel.Column) string {
+	var buffer strings.Builder
+
+	if column.Unsigned {
+		buffer.WriteString(" UNSIGNED")
+	}
+
+	if column.Unique {
+		buffer.WriteString(" UNIQUE")
+	}
+
+	if column.Required {
+		buffer.WriteString(" NOT NULL")
+	}
+
+	if column.Primary {
+		buffer.WriteString(" PRIMARY KEY")
+	}
+
+	buf := buffer.String()
+	if buf != "" {
+		buf = buf[1:]
+	}
+
+	return buf
+}
+
 // ExtractString between two string.
 func ExtractString(s, left, right string) string {
 	var (


### PR DESCRIPTION
Will need to add `ColumnOptionsMapper: sql.ColumnOptionsMapper` for all adapters, will do that once this is merged.

Needed so that it's possible to implement auto increment for ID, BigID columns for SQLite3 adapter